### PR TITLE
[WIP DO NOT MERGE] Added source_url field to manifests

### DIFF
--- a/c-sharp-hello-world/manifest.yaml
+++ b/c-sharp-hello-world/manifest.yaml
@@ -1,5 +1,5 @@
 name: C Sharp Hello World
-source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/hello-world/helloworld-csharp/README.md
+homepage_url: https://github.com/knative/docs/blob/master/docs/serving/samples/hello-world/helloworld-csharp/README.md
 tagline: A simple web app written in C# using .NET Core 2.2
 tags:
   - 'c#'

--- a/c-sharp-hello-world/manifest.yaml
+++ b/c-sharp-hello-world/manifest.yaml
@@ -1,4 +1,5 @@
 name: C Sharp Hello World
+source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/hello-world/helloworld-csharp/README.md
 tagline: A simple web app written in C# using .NET Core 2.2
 tags:
   - 'c#'

--- a/github-webhook-example/manifest.yaml
+++ b/github-webhook-example/manifest.yaml
@@ -1,5 +1,5 @@
 name: GitHub Webhook Example
-source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/gitwebhook-go/README.md
+homepage_url: https://github.com/knative/docs/blob/master/docs/serving/samples/gitwebhook-go/README.md
 tagline: A simple webhook handler that demonstrates interacting with Github.
 tags:
   - 'go'

--- a/github-webhook-example/manifest.yaml
+++ b/github-webhook-example/manifest.yaml
@@ -1,4 +1,5 @@
 name: GitHub Webhook Example
+source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/gitwebhook-go/README.md
 tagline: A simple webhook handler that demonstrates interacting with Github.
 tags:
   - 'go'

--- a/grpc-example/manifest.yaml
+++ b/grpc-example/manifest.yaml
@@ -1,4 +1,5 @@
 name: gRPC Example
+source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/grpc-ping-go/README.md
 tagline: A simple gRPC server.
 tags:
   - 'go'

--- a/grpc-example/manifest.yaml
+++ b/grpc-example/manifest.yaml
@@ -1,5 +1,5 @@
 name: gRPC Example
-source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/grpc-ping-go/README.md
+homepage_url: https://github.com/knative/docs/blob/master/docs/serving/samples/grpc-ping-go/README.md
 tagline: A simple gRPC server.
 tags:
   - 'go'

--- a/knative-autoscaling-example/manifest.yaml
+++ b/knative-autoscaling-example/manifest.yaml
@@ -1,5 +1,5 @@
 name: Knative Autoscaling Example
-source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/autoscale-go/README.md
+homepage_url: https://github.com/knative/docs/blob/master/docs/serving/samples/autoscale-go/README.md
 tagline: A demonstration of the autoscaling capabilities of Knative.
 tags:
   - 'go'

--- a/knative-autoscaling-example/manifest.yaml
+++ b/knative-autoscaling-example/manifest.yaml
@@ -1,4 +1,5 @@
 name: Knative Autoscaling Example
+source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/autoscale-go/README.md
 tagline: A demonstration of the autoscaling capabilities of Knative.
 tags:
   - 'go'

--- a/knative-routing-example/manifest.yaml
+++ b/knative-routing-example/manifest.yaml
@@ -1,5 +1,5 @@
 name: Knative Routing Example
-source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/knative-routing-go/README.md
+homepage_url: https://github.com/knative/docs/blob/master/docs/serving/samples/knative-routing-go/README.md
 tagline: An example of mapping multiple Knative services to different paths under a single domain name using the Istio VirtualService concept.
 tags:
   - 'go'

--- a/knative-routing-example/manifest.yaml
+++ b/knative-routing-example/manifest.yaml
@@ -1,4 +1,5 @@
 name: Knative Routing Example
+source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/knative-routing-go/README.md
 tagline: An example of mapping multiple Knative services to different paths under a single domain name using the Istio VirtualService concept.
 tags:
   - 'go'

--- a/knative-secrets-example/manifest.yaml
+++ b/knative-secrets-example/manifest.yaml
@@ -1,4 +1,5 @@
 name: Knative Secrets Example
+source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/secrets-go/README.md
 tagline: A small Knative example using Kubernetes secrets
 tags:
   - 'go'

--- a/knative-secrets-example/manifest.yaml
+++ b/knative-secrets-example/manifest.yaml
@@ -1,5 +1,5 @@
 name: Knative Secrets Example
-source_url: https://github.com/knative/docs/blob/master/docs/serving/samples/secrets-go/README.md
+homepage_url: https://github.com/knative/docs/blob/master/docs/serving/samples/secrets-go/README.md
 tagline: A small Knative example using Kubernetes secrets
 tags:
   - 'go'

--- a/new.sh
+++ b/new.sh
@@ -159,7 +159,7 @@ manifest_categories_choices=("analytics"
 			     "virtual assistant"
 			     "other")
 
-
+prompt "Source URL - What is a URL you would like to link users back to when viewing your app?" manifest_source_url
 prompt "Tagline - What are a few words which describe your app?" manifest_tagline
 prompt_list "Tags - What are a few keywords that fit your app?"
 manifest_tags=("${__items[@]}")
@@ -186,6 +186,7 @@ echo "Writing this manifest.yaml for your new app:"
 
 tee "$app_dir/manifest.yaml" <<EOF
 name: $name
+source_url: $manifest_source_url
 tagline: $manifest_tagline
 tags:
 $(as_yaml_list 2 "${manifest_tags[@]}")

--- a/serverless-example-go/manifest.yaml
+++ b/serverless-example-go/manifest.yaml
@@ -1,4 +1,5 @@
-name: Serverless Example Go 
+name: Serverless Example Go
+source_url: https://github.com/kscout/serverless-example-go
 tagline: Sample  Go serverless application
 tags:
   - golang

--- a/serverless-example-go/manifest.yaml
+++ b/serverless-example-go/manifest.yaml
@@ -1,5 +1,5 @@
 name: Serverless Example Go
-source_url: https://github.com/kscout/serverless-example-go
+homepage_url: https://github.com/kscout/serverless-example-go
 tagline: Sample  Go serverless application
 tags:
   - golang

--- a/serverless-example-nodejs/manifest.yaml
+++ b/serverless-example-nodejs/manifest.yaml
@@ -1,5 +1,5 @@
 name: Serverless Example NodeJS
-source_url: https://github.com/kscout/serverless-example-nodejs
+homepage_url: https://github.com/kscout/serverless-example-nodejs
 tagline: Example NodeJS serverless application
 tags:
   - NodeJS

--- a/serverless-example-nodejs/manifest.yaml
+++ b/serverless-example-nodejs/manifest.yaml
@@ -1,4 +1,5 @@
 name: Serverless Example NodeJS
+source_url: https://github.com/kscout/serverless-example-nodejs
 tagline: Example NodeJS serverless application
 tags:
   - NodeJS

--- a/serverless-example-python/manifest.yaml
+++ b/serverless-example-python/manifest.yaml
@@ -1,5 +1,5 @@
 name: Serverless Example Python
-source_url: https://github.com/kscout/serverless-example-py
+homepage_url: https://github.com/kscout/serverless-example-py
 tagline: Sample Hello-World python serverless application
 tags:
   - Python

--- a/serverless-example-python/manifest.yaml
+++ b/serverless-example-python/manifest.yaml
@@ -1,4 +1,5 @@
 name: Serverless Example Python
+source_url: https://github.com/kscout/serverless-example-py
 tagline: Sample Hello-World python serverless application
 tags:
   - Python


### PR DESCRIPTION
Adds the `source_url` field to all the existing manifest files.

This should not be merged until https://github.com/kscout/serverless-registry-api/pull/173 is deployed.